### PR TITLE
Simple refactorisation de router/film et controllers/film

### DIFF
--- a/BACK_END/controllers/film.js
+++ b/BACK_END/controllers/film.js
@@ -53,7 +53,7 @@ export const importFilms = async (_, res) => {
 export const synchronizeFilms = async () => {
   try {
     const transformedData = transformExcelData();
-    const localStorageFilms = await Film.find({});
+    const localStorageFilms = await Film.find();
     const differentIds = [];
     const idForAdd = [];
     const idForDelete = [];

--- a/BACK_END/router/film.js
+++ b/BACK_END/router/film.js
@@ -1,8 +1,10 @@
 import express from "express";
-import { importFilms } from "../controllers/film.js";
-import { getFilms } from "../controllers/film.js";
-import { countFilms } from "../controllers/film.js";
-import { searchFilmByTerm } from "../controllers/film.js";
+import {
+  importFilms,
+  getFilms,
+  countFilms,
+  searchFilmByTerm,
+} from "../controllers/film.js";
 // routes pour gérer les films
 const router = express.Router();
 router.post("/import", importFilms);


### PR DESCRIPTION
Il est possible d'importer tous les contrôleurs en 1 ligne et non plus en 4 lignes dans le fichier router/film.js.

Il est possible de ne passer aucun argument à await Film.find() pour trouver tous les films de la collection. L'objet vide n'a donc pas l'air nécessaire.